### PR TITLE
Add formatting option to `utils.print_eqx_fields`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,10 @@ cython_debug/
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
+# Vim
+*.swp
+*.vim
+
 # Ruff stuff:
 .ruff_cache/
 

--- a/jaxmat/utils.py
+++ b/jaxmat/utils.py
@@ -47,7 +47,7 @@ def partition_by_node_names(model, freeze_names):
     return trainable, static
 
 
-def print_eqx_fields(obj, fields=None, indent=0, format=""):
+def print_eqx_fields(obj, fields=None, indent=0, file=None, format=""):
     """
     Recursively print fields of an Equinox module or dataclass-like object.
 
@@ -93,7 +93,7 @@ def print_eqx_fields(obj, fields=None, indent=0, format=""):
         return template.format(*to_format)
 
     if isinstance(obj, eqx.Module):
-        print(f"{pad}{obj.__class__.__name__}:")
+        print(f"{pad}{obj.__class__.__name__}:", file=file)
         for k, v in obj.__dict__.items():
             if not matches(k):
                 continue  # skip fields not requested
@@ -115,14 +115,18 @@ def print_eqx_fields(obj, fields=None, indent=0, format=""):
                 v_formatter = format
 
             if isinstance(v, eqx.Module):
-                print(f"{pad}  {k}:")
+                print(f"{pad}  {k}:", file=file)
                 print_eqx_fields(
-                    v, fields=subfields, indent=indent + 4, format=v_formatter
+                    v,
+                    fields=subfields,
+                    indent=indent + 4,
+                    format=v_formatter,
+                    file=file,
                 )
             elif isinstance(v, (list, tuple)):
-                print(f"{pad}  {k} = {format_list_tupple(v, v_formatter)}")
+                print(f"{pad}  {k} = {format_list_tupple(v, v_formatter)}", file=file)
             else:
-                print(f"{pad}  {k} = {v:{v_formatter}}")
+                print(f"{pad}  {k} = {v:{v_formatter}}", file=file)
     elif isinstance(obj, (list, tuple)):
         for i, v in enumerate(obj):
             v_formatter: str
@@ -131,7 +135,7 @@ def print_eqx_fields(obj, fields=None, indent=0, format=""):
             else:
                 v_formatter = format
 
-            print(f"{pad}[{i}]: {v:{v_formatter}}")
+            print(f"{pad}[{i}]: {v:{v_formatter}}", file=file)
 
     else:
-        print(f"{pad}{obj}")
+        print(f"{pad}{obj}", file=file)

--- a/jaxmat/utils.py
+++ b/jaxmat/utils.py
@@ -49,7 +49,7 @@ def partition_by_node_names(model, freeze_names):
     return trainable, static
 
 
-def print_eqx_fields(obj, fields=None, indent=0, file=None, format=""):
+def print_eqx_fields(obj, fields=None, indent=0, format=""):
     """
     Recursively print fields of an Equinox module or dataclass-like object.
 
@@ -95,7 +95,7 @@ def print_eqx_fields(obj, fields=None, indent=0, file=None, format=""):
         return template.format(*to_format)
 
     if isinstance(obj, eqx.Module):
-        print(f"{pad}{obj.__class__.__name__}:", file=file)
+        print(f"{pad}{obj.__class__.__name__}:")
         for k, v in obj.__dict__.items():
             if not matches(k):
                 continue  # skip fields not requested
@@ -117,23 +117,19 @@ def print_eqx_fields(obj, fields=None, indent=0, file=None, format=""):
                 v_formatter = format
 
             if isinstance(v, eqx.Module):
-                print(f"{pad}  {k}:", file=file)
+                print(f"{pad}  {k}:")
                 print_eqx_fields(
-                    v,
-                    fields=subfields,
-                    indent=indent + 4,
-                    format=v_formatter,
-                    file=file,
+                    v, fields=subfields, indent=indent + 4, format=v_formatter
                 )
             elif isinstance(v, (list, tuple)):
-                print(f"{pad}  {k} = {format_list_tupple(v, v_formatter)}", file=file)
+                print(f"{pad}  {k} = {format_list_tupple(v, v_formatter)}")
             elif isinstance(v, (np.ndarray, jax.Array)) and v.shape is not ():
                 with np.printoptions(
                     formatter={"all": ("{:" + v_formatter + "}").format}
                 ):
-                    print(f"{pad}  {k} = {v}", file=file)
+                    print(f"{pad}  {k} = {v}")
             else:
-                print(f"{pad}  {k} = {v:{v_formatter}}", file=file)
+                print(f"{pad}  {k} = {v:{v_formatter}}")
     elif isinstance(obj, (list, tuple)):
         for i, v in enumerate(obj):
             v_formatter: str
@@ -142,7 +138,7 @@ def print_eqx_fields(obj, fields=None, indent=0, file=None, format=""):
             else:
                 v_formatter = format
 
-            print(f"{pad}[{i}]: {v:{v_formatter}}", file=file)
+            print(f"{pad}[{i}]: {v:{v_formatter}}")
 
     else:
-        print(f"{pad}{obj}", file=file)
+        print(f"{pad}{obj}")

--- a/jaxmat/utils.py
+++ b/jaxmat/utils.py
@@ -1,4 +1,5 @@
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -124,8 +125,13 @@ def print_eqx_fields(obj, fields=None, indent=0, file=None, format=""):
                     format=v_formatter,
                     file=file,
                 )
-            elif isinstance(v, (list, tuple, np.ndarray)):
+            elif isinstance(v, (list, tuple)):
                 print(f"{pad}  {k} = {format_list_tupple(v, v_formatter)}", file=file)
+            elif isinstance(v, (np.ndarray, jax.Array)) and v.shape is not ():
+                with np.printoptions(
+                    formatter={"all": ("{:" + v_formatter + "}").format}
+                ):
+                    print(f"{pad}  {k} = {v}", file=file)
             else:
                 print(f"{pad}  {k} = {v:{v_formatter}}", file=file)
     elif isinstance(obj, (list, tuple)):

--- a/jaxmat/utils.py
+++ b/jaxmat/utils.py
@@ -4,7 +4,9 @@ import jax.numpy as jnp
 
 def default_value(value, dtype=jnp.float64, **kwargs):
     """Initialize and convert a field with default `value` of imposed `dtype`."""
-    return eqx.field(converter=lambda x: jnp.asarray(x, dtype=dtype), default=value, **kwargs)
+    return eqx.field(
+        converter=lambda x: jnp.asarray(x, dtype=dtype), default=value, **kwargs
+    )
 
 
 def enforce_dtype(dtype=jnp.float64, **kwargs):
@@ -34,7 +36,9 @@ def partition_by_node_names(model, freeze_names):
             return _rgetattr(m, name)
 
         # move out of trainable
-        trainable = eqx.tree_at(sel, trainable, replace=None, is_leaf=lambda x: x is None)
+        trainable = eqx.tree_at(
+            sel, trainable, replace=None, is_leaf=lambda x: x is None
+        )
         # copy original value into static
         static = eqx.tree_at(
             sel, static, replace=_rgetattr(model, name), is_leaf=lambda x: x is None
@@ -43,7 +47,7 @@ def partition_by_node_names(model, freeze_names):
     return trainable, static
 
 
-def print_eqx_fields(obj, fields=None, indent=0):
+def print_eqx_fields(obj, fields=None, indent=0, format=""):
     """
     Recursively print fields of an Equinox module or dataclass-like object.
 
@@ -53,7 +57,9 @@ def print_eqx_fields(obj, fields=None, indent=0):
                 Supports nested paths like ["layer1", "layer2.weight"].
                 If None, prints all fields recursively.
         indent: Internal indentation level (used for recursion).
+        format: Formatter used to format Module element (syntax of str.format).
     """
+
     pad = " " * indent
 
     # Helper to match top-level field names
@@ -62,6 +68,29 @@ def print_eqx_fields(obj, fields=None, indent=0):
             return True
         # Match if this field or any nested subpath starts with it
         return any(f == field_name or f.startswith(f"{field_name}.") for f in fields)
+
+    def format_list_tupple(to_format: list | tuple, formatter: str | list) -> str:
+        """
+        Format a list or a tuple using formatter. If formatter is a string, the
+        same formatter is used for every element, if it is a list, the
+        formatter can be specified for each element of the list/tuple.
+        """
+        # Define the pair of delimiters
+        start: str
+        end: str
+        if isinstance(to_format, tuple):
+            start, end = "(", ")"
+        else:
+            start, end = "[", "]"
+
+        # Define the template
+        template: str
+        if isinstance(formatter, (list, tuple)):
+            template = start + ", ".join([f"{{:{f}}}" for f in formatter]) + end
+        else:
+            template = start + ", ".join(len(to_format) * [f"{{:{formatter}}}"]) + end
+
+        return template.format(*to_format)
 
     if isinstance(obj, eqx.Module):
         print(f"{pad}{obj.__class__.__name__}:")
@@ -72,15 +101,37 @@ def print_eqx_fields(obj, fields=None, indent=0):
             # Extract subfields relevant to this nested module (if any)
             subfields = None
             if fields is not None:
-                subfields = [f[len(k) + 1 :] for f in fields if f.startswith(f"{k}.")] or None
+                subfields = [
+                    f[len(k) + 1 :] for f in fields if f.startswith(f"{k}.")
+                ] or None
+
+            v_formatter: str
+            if isinstance(format, dict):
+                if k in format:
+                    v_formatter = format[k]
+                else:
+                    v_formatter = ""
+            else:
+                v_formatter = format
 
             if isinstance(v, eqx.Module):
                 print(f"{pad}  {k}:")
-                print_eqx_fields(v, fields=subfields, indent=indent + 4)
+                print_eqx_fields(
+                    v, fields=subfields, indent=indent + 4, format=v_formatter
+                )
+            elif isinstance(v, (list, tuple)):
+                print(f"{pad}  {k} = {format_list_tupple(v, v_formatter)}")
             else:
-                print(f"{pad}  {k} = {v}")
+                print(f"{pad}  {k} = {v:{v_formatter}}")
     elif isinstance(obj, (list, tuple)):
         for i, v in enumerate(obj):
-            print(f"{pad}[{i}]: {v}")
+            v_formatter: str
+            if isinstance(format, (list, tuple)):
+                v_formatter = format[i]
+            else:
+                v_formatter = format
+
+            print(f"{pad}[{i}]: {v:{v_formatter}}")
+
     else:
         print(f"{pad}{obj}")

--- a/jaxmat/utils.py
+++ b/jaxmat/utils.py
@@ -1,5 +1,6 @@
 import equinox as eqx
 import jax.numpy as jnp
+import numpy as np
 
 
 def default_value(value, dtype=jnp.float64, **kwargs):
@@ -123,7 +124,7 @@ def print_eqx_fields(obj, fields=None, indent=0, file=None, format=""):
                     format=v_formatter,
                     file=file,
                 )
-            elif isinstance(v, (list, tuple)):
+            elif isinstance(v, (list, tuple, np.ndarray)):
                 print(f"{pad}  {k} = {format_list_tupple(v, v_formatter)}", file=file)
             else:
                 print(f"{pad}  {k} = {v:{v_formatter}}", file=file)


### PR DESCRIPTION
This PR is a proposition of a feature for the function `utils.print_eqx_fields` to specify the format to use when printing the fields of the module (for example using scientific notation). It allows to specify a format for all the fields, or to specify the format for each fields or submodules.

Here is an example of usage:
```python
import equinox as eqx
import numpy as np
from jaxmat.utils import enforce_dtype, print_eqx_fields

class SM1(eqx.Module):
    A: float = enforce_dtype()
    B: float = enforce_dtype()

class SM2(eqx.Module):
    A: float = enforce_dtype()
    B: float = enforce_dtype()
    C: list

class M1(eqx.Module):
    A: float = enforce_dtype()
    B: float = enforce_dtype()
    C: tuple
    sub1: SM1
    sub2: SM1

sub1 = SM1(A=11, B=12)
sub2 = SM2(A=21, B=22, C=[23, 24])
mod = M1(A=31, B=32, C=(33, 34), sub1=sub1, sub2=sub2)

print_eqx_fields(mod)

print_eqx_fields(mod, format=".5e")

print_eqx_fields(mod, format={"sub1": ".2f", "sub2": ".3e"})

print_eqx_fields(mod, format={"sub1": ".2f", "sub2": ".3e", "C": (".1f", ".10f")})
```

That give:
```

M1:
  A = 31.0
  B = 32.0
  C = (33, 34)
  sub1:
    SM1:
      A = 11.0
      B = 12.0
  sub2:
    SM2:
      A = 21.0
      B = 22.0
      C = [23, 24]
M1:
  A = 3.10000e+01
  B = 3.20000e+01
  C = (3.30000e+01, 3.40000e+01)
  sub1:
    SM1:
      A = 1.10000e+01
      B = 1.20000e+01
  sub2:
    SM2:
      A = 2.10000e+01
      B = 2.20000e+01
      C = [2.30000e+01, 2.40000e+01]
M1:
  A = 31.0
  B = 32.0
  C = (33, 34)
  sub1:
    SM1:
      A = 11.00
      B = 12.00
  sub2:
    SM2:
      A = 2.100e+01
      B = 2.200e+01
      C = [2.300e+01, 2.400e+01]
M1:
  A = 31.0
  B = 32.0
  C = (33.0, 34.0000000000)
  sub1:
    SM1:
      A = 11.00
      B = 12.00
  sub2:
    SM2:
      A = 2.100e+01
      B = 2.200e+01
      C = [2.300e+01, 2.400e+01]
```