### PR TITLE
Model serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,10 @@ cython_debug/
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
+# Vim
+*.swp
+*.vim
+
 # Ruff stuff:
 .ruff_cache/
 

--- a/jaxmat/utils.py
+++ b/jaxmat/utils.py
@@ -1,10 +1,16 @@
 import equinox as eqx
 import jax.numpy as jnp
+import json
+import pathlib
+
+from typing import Callable
 
 
 def default_value(value, dtype=jnp.float64, **kwargs):
     """Initialize and convert a field with default `value` of imposed `dtype`."""
-    return eqx.field(converter=lambda x: jnp.asarray(x, dtype=dtype), default=value, **kwargs)
+    return eqx.field(
+        converter=lambda x: jnp.asarray(x, dtype=dtype), default=value, **kwargs
+    )
 
 
 def enforce_dtype(dtype=jnp.float64, **kwargs):
@@ -34,7 +40,9 @@ def partition_by_node_names(model, freeze_names):
             return _rgetattr(m, name)
 
         # move out of trainable
-        trainable = eqx.tree_at(sel, trainable, replace=None, is_leaf=lambda x: x is None)
+        trainable = eqx.tree_at(
+            sel, trainable, replace=None, is_leaf=lambda x: x is None
+        )
         # copy original value into static
         static = eqx.tree_at(
             sel, static, replace=_rgetattr(model, name), is_leaf=lambda x: x is None
@@ -72,7 +80,9 @@ def print_eqx_fields(obj, fields=None, indent=0):
             # Extract subfields relevant to this nested module (if any)
             subfields = None
             if fields is not None:
-                subfields = [f[len(k) + 1 :] for f in fields if f.startswith(f"{k}.")] or None
+                subfields = [
+                    f[len(k) + 1 :] for f in fields if f.startswith(f"{k}.")
+                ] or None
 
             if isinstance(v, eqx.Module):
                 print(f"{pad}  {k}:")
@@ -84,3 +94,46 @@ def print_eqx_fields(obj, fields=None, indent=0):
             print(f"{pad}[{i}]: {v}")
     else:
         print(f"{pad}{obj}")
+
+
+def save_model(
+    filename: str | pathlib.Path,
+    model: eqx.Module,
+    hyperparameters: dict | None = None,
+) -> None:
+    """
+    Serialize and save an Equinox Module in a file.
+
+    Args:
+        filename: Path of the file to save the module.
+        model: Model to save.
+        hyperparameters: Hyperparameters of the model, that is parameters that
+                         describe the shape of the associated PyTree.
+    """
+    with open(filename, "wb") as file:
+        if hyperparameters is not None:
+            hyperparam_str = json.dumps(hyperparameters)
+            file.write((hyperparam_str + "\n").encode())
+        eqx.tree_serialise_leaves(file, model)
+
+
+def load_model(
+    filename: str | pathlib.Path, skeleton: eqx.Module | Callable
+) -> eqx.Module:
+    """
+    Load a serialized model saved with save_model.
+
+    Args:
+        filename: Path of the file to save the module.
+        skeleton: Either an equinox module with the same shape as the PyTree
+                  to deserialize, or a function that takes hyperparameters and
+                  create such a module
+    """
+    with open(filename, "rb") as file:
+        model: eqx.Module
+        if isinstance(skeleton, eqx.Module):
+            model = skeleton
+        else:
+            hyperparameters = json.loads(file.readline().decode())
+            model = skeleton(**hyperparameters)
+        return eqx.tree_deserialise_leaves(file, model)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,45 @@
+import jax
+import jax.numpy as jnp
+import equinox as eqx
+import tempfile
+
+from jaxmat.utils import save_model, load_model, enforce_dtype
+
+
+class Module1(eqx.Module):
+    A: float = enforce_dtype()
+    B: float = enforce_dtype()
+
+
+class Module2(eqx.Module):
+    len_A: int = eqx.field(static=True)
+    A: jax.Array
+
+    def __init__(self, len_A: int, A: jax.Array | None = None):
+        self.len_A = len_A
+        if A is None:
+            self.A = jnp.zeros(len_A)
+        else:
+            assert len(A) == len_A
+            self.A = jnp.asarray(A, dtype=jnp.float64)
+
+
+def test_save_load_without_hyperparams():
+    model = Module1(A=11, B=12)
+    file = tempfile.NamedTemporaryFile()
+    save_model(file.name, model)
+    loaded_model = load_model(file.name, Module1(A=0, B=0))
+    assert eqx.tree_equal(model, loaded_model)
+
+
+def test_save_load_with_hyperparams():
+    model = Module2(len_A=3, A=[1, 2, 5])
+    file = tempfile.NamedTemporaryFile()
+    save_model(file.name, model, {"len_A": model.len_A})
+    loaded_model = load_model(file.name, lambda len_A: Module2(len_A))
+    assert eqx.tree_equal(model, loaded_model)
+
+
+if __name__ == "__main__":
+    test_save_load_without_hyperparams()
+    test_save_load_with_hyperparams()


### PR DESCRIPTION
This is a proposal for utils functions for model serialization and save on disk (cf issue #35).

I relied on this [documentation page](https://docs.kidger.site/equinox/examples/serialisation/) to make utils that can handle both model with and without hyperparameters.

It still needs to be tested with material model (ie a module that inherit from `AbstractBehavior` or `SmallStrainBehavior`).
